### PR TITLE
added german translation support for grunttype dts output and makes future translations easier

### DIFF
--- a/src/controllers/invasion.js
+++ b/src/controllers/invasion.js
@@ -1,6 +1,7 @@
 const Controller = require('./controller')
 const config = require('config')
 const log = require('../logger')
+const path = require('path')
 
 const _ = require('lodash')
 const mustache = require('mustache')
@@ -12,6 +13,12 @@ require('moment-precise-range-plugin')
 
 moment.locale(config.locale.timeformat)
 const minTth = config.general.monsterMinimumTimeTillHidden || 0
+
+let gruntTypeDataPath = path.join(__dirname, '../util/grunt_types.json')
+//Check if the config language is one of the array object (array for future translation possibilities)
+if (_.includes(['de'], config.locale.language.toLowerCase())) {
+	gruntTypeDataPath = path.join(__dirname, `../util/locale/grunt_types${config.locale.language.toLowerCase()}.json`)
+}
 
 const dts = require('../../config/dts')
 const emojiData = require('../../config/emoji')

--- a/src/util/locale/grunt_typesde.json
+++ b/src/util/locale/grunt_typesde.json
@@ -1,0 +1,207 @@
+{
+    "0": {
+       "type": "Zufall",
+       "grunt": "Zufall",
+       "gender": 0
+    },
+    "1": {
+      "type": "",
+      "grunt": "Blanche",
+      "gender": 2
+    },
+    "2": {
+      "type": "",
+      "grunt": "Candela",
+      "gender": 2
+    },
+    "3": {
+      "type": "",
+      "grunt": "Spark",
+      "gender": 1
+    },
+    "4": {
+      "type": "Gemischt",
+      "grunt": "Männlicher Rüpel", 
+      "gender": 1
+    },
+    "5": {
+      "type": "Gemischt",
+      "grunt": "Weiblicher Rüpel",
+      "gender": 2
+    },
+    "6": {
+      "type": "Käfer",
+      "grunt": "Weiblicher Rüpel",
+      "gender": 2
+    },
+    "7": {
+      "type": "Käfer",
+      "grunt": "Männlicher Rüpel", 
+      "gender": 1
+    },
+    "8": {
+      "type": "Geist",
+      "grunt": "Weiblicher Rüpel",
+      "gender": 2
+    },
+    "9": {
+      "type": "Geist",
+      "grunt": "Männlicher Rüpel", 
+      "gender": 1
+    },
+    "10": {
+      "type": "Unlicht",
+      "grunt": "Weiblicher Rüpel",
+      "gender": 2
+    },
+    "11": {
+      "type": "Unlicht",
+      "grunt": "Männlicher Rüpel", 
+      "gender": 1
+    },
+    "12": {
+      "type": "Drache",
+      "grunt": "Weiblicher Rüpel",
+      "gender": 2
+    },
+    "13": {
+      "type": "Drache",
+      "grunt": "Männlicher Rüpel", 
+      "gender": 1
+    },
+    "14": {
+      "type": "Fee",
+      "grunt": "Weiblicher Rüpel",
+      "gender": 2
+    },
+    "15": {
+      "type": "Fee",
+      "grunt": "Männlicher Rüpel", 
+      "gender": 1
+    },
+    "16": {
+      "type": "Kampf",
+      "grunt": "Weiblicher Rüpel",
+      "gender": 2
+    },
+    "17": {
+      "type": "Kampf",
+      "grunt": "Männlicher Rüpel", 
+      "gender": 1
+    },
+    "18": {
+      "type": "Feuer",
+      "grunt": "Weiblicher Rüpel",
+      "gender": 2
+    },
+    "19": {
+      "type": "Feuer",
+      "grunt": "Männlicher Rüpel", 
+      "gender": 1
+    },
+    "20": {
+      "type": "Flug",
+      "grunt": "Weiblicher Rüpel",
+      "gender": 2
+    },
+    "21": {
+      "type": "Flug",
+      "grunt": "Männlicher Rüpel", 
+      "gender": 1
+    },
+    "22": {
+      "type": "Pflanze",
+      "grunt": "Weiblicher Rüpel",
+      "gender": 2
+    },
+    "23": {
+      "type": "Pflanze",
+      "grunt": "Männlicher Rüpel", 
+      "gender": 1
+    },
+    "24": {
+      "type": "Boden",
+      "grunt": "Weiblicher Rüpel",
+      "gender": 2
+    },
+    "25": {
+      "type": "Boden",
+      "grunt": "Männlicher Rüpel", 
+      "gender": 1
+    },
+    "26": {
+      "type": "Eis",
+      "grunt": "Weiblicher Rüpel",
+      "gender": 2
+    },
+    "27": {
+      "type": "Eis",
+      "grunt": "Männlicher Rüpel", 
+      "gender": 1
+    },
+    "28": {
+      "type": "Stahl",
+      "grunt": "Weiblicher Rüpel",
+      "gender": 2
+    },
+    "29": {
+      "type": "Stahl",
+      "grunt": "Männlicher Rüpel", 
+      "gender": 1
+    },
+    "30": {
+      "type": "Normal",
+      "grunt": "Weiblicher Rüpel",
+      "gender": 2
+    },
+    "31": {
+      "type": "Normal",
+      "grunt": "Männlicher Rüpel", 
+      "gender": 1
+    },
+    "32": {
+      "type": "Gift",
+      "grunt": "Weiblicher Rüpel",
+      "gender": 2
+    },
+    "33": {
+      "type": "Gift",
+      "grunt": "Männlicher Rüpel", 
+      "gender": 1
+    },
+    "34": {
+      "type": "Psycho",
+      "grunt": "Weiblicher Rüpel",
+      "gender": 2
+    },
+    "35": {
+      "type": "Psycho",
+      "grunt": "Männlicher Rüpel", 
+      "gender": 1
+    },
+    "36": {
+      "type": "Gestein",
+      "grunt": "Weiblicher Rüpel",
+      "gender": 2
+    },
+    "37": {
+      "type": "Gestein",
+      "grunt": "Männlicher Rüpel", 
+      "gender": 1
+    },
+    "38": {
+      "type": "Wasser",
+      "grunt": "Weiblicher Rüpel",
+      "gender": 2
+    },
+    "39": {
+      "type": "Wasser",
+      "grunt": "Männlicher Rüpel",
+      "gender": 1
+    },
+    "40": {
+      "type": "",
+      "grunt": "Player Team Leader",
+      "gender": 0
+    }
+  }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
Added translations for dts `{{{gruntType}}}` output
## Description
<!--- Describe your changes in detail -->
The changes are made for german translations, but also include a way to easily implement other language translations
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Poracle has a few german users, which really appreciate translations for output texts

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally with dts `{{{gruntType}}}` used, it worked fine and i had my invasion gruntTypes translated
## Screenshots (if appropriate):
[https://puu.sh/E0pKW/c0f1563dac.png](url)
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `npm run lint`. Fix anything it is unhappy about -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.